### PR TITLE
유저 엔티티 리팩토링, 게시글, 댓글에 유저 연관관계 추가

### DIFF
--- a/src/main/java/com/ridingmate/api/entity/BoardEntity.java
+++ b/src/main/java/com/ridingmate/api/entity/BoardEntity.java
@@ -43,8 +43,14 @@ public abstract class BoardEntity extends BaseTime {
     @OneToMany(mappedBy = "board")
     private List<CommentEntity> comments = new ArrayList<>();
 
+    // 게시글 작성자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
     //TODO : 썸네일 저장을 위한 location 저장 컬럼
     //        File에 대한 entity 필요할거같음 생성해서 연관관계 연결
     //TODO : 내용과 사진을 같이 저장할 BLOB와 같은 컬럼
+
 
 }

--- a/src/main/java/com/ridingmate/api/entity/CommentEntity.java
+++ b/src/main/java/com/ridingmate/api/entity/CommentEntity.java
@@ -36,4 +36,9 @@ public class CommentEntity extends BaseTime {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id")
     private BoardEntity board;
+
+    // 댓글 작성자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
 }

--- a/src/main/java/com/ridingmate/api/entity/NormalUserEntity.java
+++ b/src/main/java/com/ridingmate/api/entity/NormalUserEntity.java
@@ -1,0 +1,49 @@
+package com.ridingmate.api.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sun.istack.NotNull;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+
+@Entity
+@Table(name = "RMC_USER")
+@DynamicInsert
+@DynamicUpdate
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NormalUserEntity extends UserEntity {
+
+    /**
+     * 일반 유저 엔티티
+     * 아이디, 비밀번호로 로그인하는 유저
+     */
+
+
+    // TODO : 인증 로직 완성후 제거 -> UserEntity에서 공통으로 관리
+    @Column(name = "uuid")
+    private String uuid;
+
+    //핸드폰 번호
+    @Column(name = "phone_number")
+    @NotNull
+    private String phoneNumber;
+
+    //생일
+    @Column(name = "date_of_birth")
+    private LocalDate dateOfBirth;
+
+    //비밀번호
+    @Column(name = "password")
+    @JsonIgnore
+    @NotNull
+    private String password;
+
+
+}

--- a/src/main/java/com/ridingmate/api/entity/SocialUserEntity.java
+++ b/src/main/java/com/ridingmate/api/entity/SocialUserEntity.java
@@ -1,0 +1,20 @@
+package com.ridingmate.api.entity;
+
+import com.ridingmate.api.entity.value.SocialType;
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@DiscriminatorValue("SOCIAL")
+public class SocialUserEntity extends UserEntity {
+
+    /**
+     * 소셜 유저 엔티티
+     */
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_type")
+    private SocialType socialType;
+}

--- a/src/main/java/com/ridingmate/api/entity/UserEntity.java
+++ b/src/main/java/com/ridingmate/api/entity/UserEntity.java
@@ -1,58 +1,34 @@
 package com.ridingmate.api.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.sun.istack.NotNull;
-import lombok.*;
-import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.DynamicUpdate;
+import com.ridingmate.api.entity.value.UserRole;
+import lombok.Getter;
 
 import javax.persistence.*;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
-@Table(name = "RMC_USER")
-@DynamicInsert
-@DynamicUpdate
 @Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class UserEntity extends BaseTime {
+@Table(name = "RMC_USER")
+@DiscriminatorColumn(name = "user_type")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+public abstract class UserEntity extends BaseTime {
 
-    //TODO : OAuth2 사용해서 어떤거 저장되는지 확인 해야함
+    /**
+     * 유저 공통 엔티티
+     */
 
     @Id
     @Column(name = "idx")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long idx;
+    private Long idx;
 
-    //고유번호
-    @Column
-    @NotNull
-    private String uuid;
+    @Column(name = "user_uuid")
+    private String userUuid;
 
-    //핸드폰 번호
-    @Column(name = "phone_number")
-    @NotNull
-    private String phoneNumber;
+    @Column(name = "nickname")
+    private String nickname;
 
-    //생일
-    @Column(name = "date_of_birth")
-    private LocalDate dateOfBirth;
-
-    //비밀번호
-    @Column(name = "password")
-    @JsonIgnore
-    @NotNull
-    private String password;
-
-    //권한
-    @Column(name = "role")
-    @JsonIgnore
-    @NotNull
-    private String role;
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
 
     //TODO : 하나의 유저는 여러개의 바이크를 가질 수 있다.
     //TODO : 하나의 유저는 여러개의 중고거래 글을 쓸 수 있다.

--- a/src/main/java/com/ridingmate/api/repository/UserRepository.java
+++ b/src/main/java/com/ridingmate/api/repository/UserRepository.java
@@ -1,12 +1,12 @@
 package com.ridingmate.api.repository;
 
-import com.ridingmate.api.entity.UserEntity;
+import com.ridingmate.api.entity.NormalUserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
-public interface UserRepository extends JpaRepository<UserEntity, Long> {
+public interface UserRepository extends JpaRepository<NormalUserEntity, Long> {
 
 
 }

--- a/src/main/java/com/ridingmate/api/security/UserPrincipal.java
+++ b/src/main/java/com/ridingmate/api/security/UserPrincipal.java
@@ -1,5 +1,6 @@
 package com.ridingmate.api.security;
 
+import com.ridingmate.api.entity.NormalUserEntity;
 import com.ridingmate.api.entity.UserEntity;
 import lombok.Getter;
 import lombok.Setter;
@@ -74,13 +75,13 @@ public class UserPrincipal implements UserDetails {
         return true;
     }
 
-    public static UserPrincipal create(UserEntity user) {
+    public static UserPrincipal create(NormalUserEntity user) {
         return new UserPrincipal(
                 user.getIdx(),
                 user.getPhoneNumber(),
                 user.getPassword(),
                 user.getUuid(),
-                user.getRole()
+                user.getRole().toString()
         );
     }
 }


### PR DESCRIPTION
1. 유저 엔티티 추상 클래스로 변경
2. 일반 유저, 소셜 유저 클래스 생성 후 알맞은 엔티티에 데이터 이동 
3. 인증 객체 코드 수정